### PR TITLE
Allow specifying options to ignore warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,18 @@
 var path = require('path');
 var notifier = require('node-notifier');
 
-var WebpackNotifierPlugin = module.exports = function() {
+var WebpackNotifierPlugin = module.exports = function(options) {
     this.lastBuildSucceeded = false;
+    this.options = options || {};
 };
 
 WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
     var error;
-    if (stats.hasWarnings()) {
-        error = stats.compilation.warnings[0];
-    }
     if (stats.hasErrors()) {
         error = stats.compilation.errors[0];
+    }
+    if (!error && stats.hasWarnings() && !this.options.excludeWarnings) {
+        error = stats.compilation.warnings[0];
     }
 
     if (error) {


### PR DESCRIPTION
I have a dependency that results in a warning every time it builds (the request of a dependency is an expression). I don't think that there's a way for me to avoid this one, so I'd prefer to be able to specify that I don't want to show warnings.