### PR TITLE
Avoiding undefined issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
         this.lastBuildSucceeded = true;
         return 'Build successful';
     }
+    if (!error) {
+      return;
+    }
 
     this.lastBuildSucceeded = false;
 


### PR DESCRIPTION
If the options `excludeWarnings` and the `stats.hasWarnings()` then `error` will be undefined and you get an error which breaks your build.