### PR TITLE
add alwaysNotify option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
     } else if (stats.hasWarnings() && !this.options.excludeWarnings) {
         error = stats.compilation.warnings[0];
 
-    } else if (!this.lastBuildSucceeded) {
+    } else if (!this.lastBuildSucceeded || this.options.alwaysNotify) {
         this.lastBuildSucceeded = true;
         return 'Build successful';
 


### PR DESCRIPTION
My builds take on the order of 1-2 seconds so it is nice to be able to save a file, and refresh once I see the notification.  Without this change I have to guess how long it has been since I saved which is frustrating when I get it wrong and end up using old code rather than new code.