### PR TITLE
Use icon as well as contentType

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ WebpackNotifierPlugin.prototype.compilationDone = function(stats) {
             title: this.options.title || 'Webpack',
             message: msg,
             contentImage: contentImage,
+            icon: contentImage
         });
     }
 };

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ WebpackNotifierPlugin.prototype.compilationDone = function(stats) {
             title: this.options.title || 'Webpack',
             message: msg,
             contentImage: contentImage,
-            icon: contentImage
+            icon: (os.platform() === 'win32') ? contentImage : undefined
         });
     }
 };


### PR DESCRIPTION
On Windows the contentImage is not displayed - this PR makes use of icon which does display on Windows. To resolve #8

Result is this: 

![image](https://cloud.githubusercontent.com/assets/1010525/10431145/51b5277e-70fb-11e5-9948-2d5f4875f81d.png)
