### PR TITLE
Prefix error + warning messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ var WebpackNotifierPlugin = module.exports = function(options) {
 WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
     var error;
     if (stats.hasErrors()) {
-        error = 'Error: ' + stats.compilation.errors[0];
+        error = stats.compilation.errors[0];
 
     } else if (stats.hasWarnings() && !this.options.excludeWarnings) {
-        error = 'Warning: ' + stats.compilation.warnings[0];
+        error = stats.compilation.warnings[0];
 
     } else if (!this.lastBuildSucceeded || this.options.alwaysNotify) {
         this.lastBuildSucceeded = true;
@@ -32,9 +32,9 @@ WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
         message = error.module.rawRequest + '\n';
 
     if (error.error)
-        message += error.error.toString();
+        message = 'Error: ' + message + error.error.toString();
     else if (error.warning)
-        message += error.warning.toString();
+        message = 'Warning: ' + message + error.warning.toString();
 
     return message;
 };

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ var WebpackNotifierPlugin = module.exports = function(options) {
 WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
     var error;
     if (stats.hasErrors()) {
-        error = stats.compilation.errors[0];
+        error = 'Error: ' + stats.compilation.errors[0];
 
     } else if (stats.hasWarnings() && !this.options.excludeWarnings) {
-        error = stats.compilation.warnings[0];
+        error = 'Warning: ' + stats.compilation.warnings[0];
 
     } else if (!this.lastBuildSucceeded || this.options.alwaysNotify) {
         this.lastBuildSucceeded = true;


### PR DESCRIPTION
Since your file names are pretty long normally, the only thing I can see in the notifications are the filenames. I'd prefer to have the notification start with `Error:` or `Warning:` instead.