### PR TITLE
Open editor when clicking on notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,13 @@ Trigger a notification every time.  Call it "noisy-mode".
 ```js
 new WebpackNotifierPlugin({alwaysNotify: true});
 ```
+
+### Editor
+
+Opens the file in your editor when the notification is clicked.
+
+Takes a command and a list or arguments interpreted as template strings. Available options are `file`, `line` and `column`. Note that lines and columns of errors are only set when using a preprocessor like babel.
+
+```js
+new WebpackNotifierPlugin({ editor: { command: 'atom', args: ['${file}:${line}'] } });
+```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Tobias Bieniek <tobias.bieniek@gmx.de>",
   "license": "ISC",
   "dependencies": {
+    "es6-template-strings": "^2.0.0",
     "node-notifier": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Still not sure how to open the editor at the correct line/position. At least in atom you can do `atom editor filename:line` but it might break other editors.

One option would to let the user supply a templated string to exec instead - like `atom #{file}:#{row}`.
