### PR TITLE
Use contentImage as icon on linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ WebpackNotifierPlugin.prototype.compilationDone = function(stats) {
             title: this.options.title || 'Webpack',
             message: msg,
             contentImage: contentImage,
-            icon: (os.platform() === 'win32') ? contentImage : undefined
+            icon: (os.platform() === 'win32' || os.platform() === 'linux') ? contentImage : undefined
         });
     }
 };


### PR DESCRIPTION
Displaying an image/icon on linux did not work for me using the contentImage parameter. However node-notifier supports displaying an icon on linux if it is passed in as "icon" parameter instead. I have seen, that this is somehow already handled as a special case for win32, so i just added linux to the list and that fixed it for me. Tested on Ubuntu 16.04.