### PR TITLE
Add option to skip notifications on first build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ Trigger a notification every time.  Call it "noisy-mode".
 ```js
 new WebpackNotifierPlugin({alwaysNotify: true});
 ```
+
+### Skip Notification on the First Build
+
+Do not notify on the first build.  This allows you to receive notifications on subsequent incremental builds without being notified on the initial build.
+
+```js
+new WebpackNotifierPlugin({skipFirstNotification: true});
+```

--- a/index.js
+++ b/index.js
@@ -9,9 +9,18 @@ var DEFAULT_LOGO = path.join(__dirname, 'logo.png');
 var WebpackNotifierPlugin = module.exports = function(options) {
     this.options = options || {};
     this.lastBuildSucceeded = false;
+    this.isFirstBuild = true;
 };
 
 WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
+    if (this.isFirstBuild) {
+        this.isFirstBuild = false;
+
+        if (this.options.skipFirstNotification) {
+            return;
+        }
+    }
+
     var error;
     if (stats.hasErrors()) {
         error = stats.compilation.errors[0];


### PR DESCRIPTION
With complex build configs, you can end up with lots of notifications on the initial build, which can be annoying, so it's convenient to have the option to skip them on the initial build and only get them on incremental builds (when using `alwaysNotify: true`).  It was sufficiently trivial to add it that I decided to open a full PR rather than ask about it via an issue first.

I've tried to match the style of the existing code, but let me know if there's something you'd like tweaked.  I'm also open to bikeshedding on the option name, if you have something else you'd prefer.