### PR TITLE
Updates node-notifier dependency to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Tobias Bieniek <tobias.bieniek@gmx.de>",
   "license": "ISC",
   "dependencies": {
-    "node-notifier": "^4.1.0",
+    "node-notifier": "^5.0.1",
     "object-assign": "^4.1.0",
     "strip-ansi": "^3.0.1"
   },


### PR DESCRIPTION
Updates the dependency of `node-notifier` to the latest [newly released `v5.0.1`](https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md#v500).

With this change there are a lot fewer dependencies as the built in CLI is removed, and other dependencies are trimmed. In addition it gives better Windows support with custom sounds and more stable activation/timeout.

For macOS it adds ability to reply/add buttons.

As you provide ability to pass through options all the way to node-notifier I'd recommend doing a minor or even major release here. It shouldn't have broken the API, but it returns different output and I don't want to guarantee that some existing use case works exactly the same way due to the nature of the changes.