### PR TITLE
Ability to suppress success message

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ If set to `true`, warnings will not cause a notification.
 new WebpackNotifierPlugin({excludeWarnings: true});
 ```
 
+### Exclude Build Successful (but show Warnings)
+
+If set to `true`, successful builds will not cause a notification.
+
+```js
+new WebpackNotifierPlugin({excludeSuccess: true});
+```
+
 ### Always Notify
 
 Trigger a notification every time.  Call it "noisy-mode".

--- a/index.js
+++ b/index.js
@@ -30,7 +30,10 @@ WebpackNotifierPlugin.prototype.compileMessage = function(stats) {
 
     } else if (!this.lastBuildSucceeded || this.options.alwaysNotify) {
         this.lastBuildSucceeded = true;
-        return 'Build successful';
+        if(this.options.excludeSuccess)
+            return;
+        else
+            return 'Build successful';
 
     } else {
         return;


### PR DESCRIPTION
When using a file watcher that automatically rebuilds, the "Build Successful" notification appears frequently (everytime you save a file).

This optional parameter (defaulted to OFF) allows you to suppress that notification while still showing error notifications.