### PR TITLE
Add support for webpack 4 plugin system

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,5 +69,11 @@ WebpackNotifierPlugin.prototype.compilationDone = function(stats) {
 };
 
 WebpackNotifierPlugin.prototype.apply = function(compiler) {
+  if (compiler.hooks) {
+    var plugin = { name: 'Notifier' };
+
+    compiler.hooks.done.tap(plugin, this.compilationDone.bind(this));
+  } else {
     compiler.plugin('done', this.compilationDone.bind(this));
+  }
 };


### PR DESCRIPTION
By detecting the new plugin API, backwards compatibility is maintained for older webpack versions as well

fixes #38