### PR TITLE
add support for title function for dynamic titles

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,12 +74,17 @@ WebpackNotifierPlugin.prototype.compilationDone = function(stats) {
         var contentImage = ('contentImage' in this.options) ?
             this.options.contentImage : DEFAULT_LOGO;
 
+        var title = this.options.title
+        if (typeof title === 'function') {
+            title = title({msg: msg})
+        }
+
         notifier.notify(objectAssign({
             title: 'Webpack',
             message: msg,
             contentImage: contentImage,
             icon: (os.platform() === 'win32' || os.platform() === 'linux') ? contentImage : undefined
-        }, this.options));
+        }, this.options, { title: title }));
     }
 };
 


### PR DESCRIPTION
allows you to do something like this to show different titles for different conditions:

```js
return new WebpackNotifierPlugin({
  title({msg}) {
    if (msg.startsWith('Error')) {
      return 'build error ❌';
    } else if (msg.startsWith('Warning')) {
      return 'build warning ⚠️';
    }
    return 'build complete ✅';
  },
});
```