### PR TITLE
Update node-notifier to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Tobias Bieniek <tobias.bieniek@gmx.de>",
   "license": "ISC",
   "dependencies": {
-    "node-notifier": "^5.1.2",
+    "node-notifier": "^6.0.0",
     "object-assign": "^4.1.0",
     "strip-ansi": "^3.0.1"
   },


### PR DESCRIPTION
Toast notifications are currently broken on Windows. node-notifier 6.0.0 uses the latest version of SnoreToast.exe which fixes the issue:
https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md