### PR TITLE
Open editor when clicking on notification [2]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,10 @@ module.exports = {
   ],
   rules: {
     'vars-on-top': 0,
-    'consistent-return': 0
+    'consistent-return': 0,
+    'no-nested-ternary': 0,
+    'one-var': 0,
+    'one-var-declaration-per-line': 0,
+    'object-curly-newline': 0
   }
 };

--- a/README.md
+++ b/README.md
@@ -131,3 +131,13 @@ Do not notify on the first build.  This allows you to receive notifications on s
 ```js
 new WebpackNotifierPlugin({skipFirstNotification: true});
 ```
+
+### Editor
+
+Opens the file in your editor when the notification is clicked.
+
+Takes a command and a list or arguments interpreted as template strings. Available options are `file`, `line` and `column`. Note that lines and columns of errors are only set when using a preprocessor like babel.
+
+```js
+new WebpackNotifierPlugin({ editor: { command: 'atom', args: ['${file}:${line}'] } });
+```

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -7,6 +7,15 @@ module.exports = {
         filename: "bundle.js"
     },
     plugins: [
-        new WebpackNotifierPlugin(),
+        new WebpackNotifierPlugin({
+            editor: {
+                command: 'C:\\Program Files\\JetBrains\\WebStorm 2019.2.4\\bin\\webstorm.bat',
+                args: [
+                  '--line', '${line}',
+                  '--column', '${column}',
+                  '${file}',
+                ]
+            }
+        }),
     ]
 };

--- a/index.js
+++ b/index.js
@@ -80,23 +80,32 @@ WebpackNotifierPlugin.prototype.compileEndOptions = function (stats) {
 
   this.lastBuildSucceeded = false;
 
-  var message = '';
-  if (error.module && error.module.rawRequest) {
-    message = error.module.rawRequest + '\n';
+  var rawRequest, resource, line, column;
+
+  if (error.module) {
+    rawRequest = error.module.rawRequest;
+    resource = error.module.resource;
   }
 
-  if (error.error) {
-    message = (hasEmoji ? '❌ ' : '') + 'Error: ' + message + error.error.toString();
-  } else if (error.warning) {
-    message = (hasEmoji ? '⚠️ ' : '') + 'Warning: ' + message + error.warning.toString();
-  } else if (error.message) {
-    message = (hasEmoji ? '⚠️ ' : '') + 'Warning: ' + message + error.message.toString();
+  var errorOrWarning = error.error || error.warning || error.message;
+  if (errorOrWarning && errorOrWarning.loc) {
+    line = errorOrWarning.loc.line;
+    column = errorOrWarning.loc.column;
   }
+
+  var message = (error.error ? (hasEmoji ? '❌ ' : '') + 'Error: ' : (error.warning || error.message) ? (hasEmoji ? '⚠️ ' : '') + 'Warning: ' : '')
+               + (rawRequest ? rawRequest + '\n' : '')
+               + (errorOrWarning ? errorOrWarning.toString() : '');
 
   return {
     message: stripANSI(message),
     contentImage: contentImage,
-    status: status
+    status: status,
+    location: {
+      file: resource,
+      line: line,
+      column: column
+    }
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var stripANSI = require('strip-ansi');
 var path = require('path');
 var os = require('os');
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 var notifier = require('node-notifier');
 var template = require('es6-template-strings');
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "Tobias Bieniek <tobias.bieniek@gmx.de>",
   "license": "ISC",
   "dependencies": {
+    "es6-template-strings": "^2.0.0",
     "node-notifier": "^8.0.0",
     "strip-ansi": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "es6-template-strings": "^2.0.0",
-    "node-notifier": "^8.0.0",
+    "node-notifier": "mikaelbr/node-notifier#e55bd8fa64",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "Tobias Bieniek <tobias.bieniek@gmx.de>",
   "license": "ISC",
   "dependencies": {
+    "cross-spawn": "^7.0.3",
     "es6-template-strings": "^2.0.0",
     "node-notifier": "mikaelbr/node-notifier#e55bd8fa64",
     "strip-ansi": "^6.0.0"

--- a/test/VerbosityLevelAllVariants.test.ts
+++ b/test/VerbosityLevelAllVariants.test.ts
@@ -1,7 +1,8 @@
-import {contentImageSerializer, reduceArraySerializer, testChangesFlow} from './helpers/utils';
+import {changedOptionsSerializer, contentImageSerializer, reduceArraySerializer, testChangesFlow} from './helpers/utils';
 
 expect.addSnapshotSerializer(reduceArraySerializer);
 expect.addSnapshotSerializer(contentImageSerializer);
+expect.addSnapshotSerializer(changedOptionsSerializer);
 
 describe('VerbosityLevelAllVariants', () => {
   describe.each([...generateOptions()])('%j', (opts) => {

--- a/test/VerbosityLevelAllVariants.test.ts
+++ b/test/VerbosityLevelAllVariants.test.ts
@@ -1,7 +1,14 @@
-import {changedOptionsSerializer, contentImageSerializer, reduceArraySerializer, testChangesFlow} from './helpers/utils';
+import {
+  changedOptionsSerializer,
+  contentImageSerializer,
+  reduceArraySerializer,
+  skipNotifierCallback,
+  testChangesFlow
+} from './helpers/utils';
 
 expect.addSnapshotSerializer(reduceArraySerializer);
 expect.addSnapshotSerializer(contentImageSerializer);
+expect.addSnapshotSerializer(skipNotifierCallback);
 expect.addSnapshotSerializer(changedOptionsSerializer);
 
 describe('VerbosityLevelAllVariants', () => {

--- a/test/WebpackNotifierPlugin.test.ts
+++ b/test/WebpackNotifierPlugin.test.ts
@@ -1,10 +1,18 @@
 import {join} from 'path';
-import {contentImageSerializer, reduceArraySerializer, changedOptionsSerializer, testChangesFlow, TestArguments} from './helpers/utils';
+import {
+  contentImageSerializer,
+  reduceArraySerializer,
+  changedOptionsSerializer,
+  testChangesFlow,
+  TestArguments,
+  skipNotifierCallback
+} from './helpers/utils';
 import CustomWarningPlugin from './helpers/CustomWarningPlugin';
 import ChildCompilationPlugin from './helpers/ChildCompilationPlugin';
 
 expect.addSnapshotSerializer(reduceArraySerializer);
 expect.addSnapshotSerializer(contentImageSerializer);
+expect.addSnapshotSerializer(skipNotifierCallback);
 expect.addSnapshotSerializer(changedOptionsSerializer);
 
 describe('WebpackNotifierPlugin', () => {

--- a/test/WebpackNotifierPlugin.test.ts
+++ b/test/WebpackNotifierPlugin.test.ts
@@ -1,10 +1,11 @@
 import {join} from 'path';
-import {contentImageSerializer, reduceArraySerializer, testChangesFlow, TestArguments} from './helpers/utils';
+import {contentImageSerializer, reduceArraySerializer, changedOptionsSerializer, testChangesFlow, TestArguments} from './helpers/utils';
 import CustomWarningPlugin from './helpers/CustomWarningPlugin';
 import ChildCompilationPlugin from './helpers/ChildCompilationPlugin';
 
 expect.addSnapshotSerializer(reduceArraySerializer);
 expect.addSnapshotSerializer(contentImageSerializer);
+expect.addSnapshotSerializer(changedOptionsSerializer);
 
 describe('WebpackNotifierPlugin', () => {
   describe('one compilation', () => {

--- a/test/__snapshots__/VerbosityLevelAllVariants.test.ts.snap
+++ b/test/__snapshots__/VerbosityLevelAllVariants.test.ts.snap
@@ -5,11 +5,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -18,11 +24,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -31,11 +43,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -44,11 +62,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -57,11 +81,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -70,10 +100,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -82,11 +114,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -95,11 +133,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -108,11 +152,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -121,11 +171,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -134,11 +190,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -147,11 +209,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -160,11 +228,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -173,10 +247,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -185,11 +261,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -198,10 +280,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -212,11 +296,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -225,10 +315,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -237,11 +329,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -250,11 +348,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -263,10 +367,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -275,11 +381,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -288,11 +400,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -301,11 +419,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -314,11 +438,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -327,10 +457,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -339,11 +471,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -352,11 +490,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -365,11 +509,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -378,11 +528,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -391,11 +547,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -404,11 +566,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -417,11 +585,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -430,11 +604,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -443,11 +623,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -456,10 +642,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -468,11 +656,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -481,10 +675,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -493,10 +689,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -505,11 +703,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -518,10 +722,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -530,11 +736,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -543,11 +755,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -556,10 +774,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -568,11 +788,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -581,10 +807,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -595,10 +823,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -611,10 +841,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -625,11 +857,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -638,10 +876,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -652,11 +892,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -665,10 +911,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -677,11 +925,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -690,10 +944,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -702,10 +958,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -714,11 +972,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -727,10 +991,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -739,11 +1005,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -752,11 +1024,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -765,10 +1043,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -777,11 +1057,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -790,10 +1076,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -802,11 +1090,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -815,11 +1109,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -828,11 +1128,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -841,11 +1147,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -854,10 +1166,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -866,11 +1180,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -879,11 +1199,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -892,11 +1218,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -905,11 +1237,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -918,11 +1256,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -931,11 +1275,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -944,11 +1294,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -957,10 +1313,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -969,11 +1327,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -982,10 +1346,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -996,11 +1362,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1009,10 +1381,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1021,11 +1395,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1034,11 +1414,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1047,10 +1433,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1059,11 +1447,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1072,11 +1466,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1085,11 +1485,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1098,11 +1504,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1111,10 +1523,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1123,11 +1537,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1136,11 +1556,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1149,11 +1575,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1162,11 +1594,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1175,11 +1613,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1188,11 +1632,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1201,11 +1651,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1214,11 +1670,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1229,11 +1691,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1242,11 +1710,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1257,11 +1731,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1270,10 +1750,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1284,11 +1766,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1297,11 +1785,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1312,11 +1806,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1327,11 +1827,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1340,10 +1846,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1354,10 +1862,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1370,10 +1880,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1382,11 +1894,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1397,10 +1915,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1411,11 +1931,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1424,11 +1950,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1439,10 +1971,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1451,11 +1985,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1466,11 +2006,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1479,11 +2025,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1494,11 +2046,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1509,11 +2067,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1522,11 +2086,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1537,11 +2107,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1552,10 +2128,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1564,11 +2142,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1579,11 +2163,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1592,11 +2182,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1607,11 +2203,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1622,10 +2224,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1636,10 +2240,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1652,10 +2258,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1664,11 +2272,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1679,10 +2293,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1691,11 +2307,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1706,11 +2328,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1721,10 +2349,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1733,11 +2363,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1748,11 +2384,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1761,11 +2403,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1776,11 +2424,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1791,11 +2445,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1804,11 +2464,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1819,11 +2485,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1832,10 +2504,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1846,11 +2520,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1861,11 +2541,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1874,11 +2560,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1889,11 +2581,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1902,10 +2600,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1916,10 +2616,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1932,10 +2634,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1946,11 +2650,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1959,10 +2669,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1973,11 +2685,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -1988,11 +2706,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2001,10 +2725,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2015,11 +2741,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2030,11 +2762,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2043,11 +2781,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2058,11 +2802,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2073,11 +2823,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2086,11 +2842,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2099,11 +2861,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2112,11 +2880,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2125,11 +2899,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2140,11 +2920,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2153,11 +2939,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2168,11 +2960,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2181,11 +2979,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2194,11 +2998,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2207,11 +3017,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2222,11 +3038,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2239,11 +3061,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2256,11 +3084,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2271,11 +3105,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2284,11 +3124,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2299,11 +3145,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2316,11 +3168,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2333,11 +3191,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2348,11 +3212,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2361,11 +3231,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2374,11 +3250,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2389,11 +3271,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2406,11 +3294,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2423,11 +3317,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2438,11 +3338,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2471,11 +3377,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2506,11 +3418,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2519,11 +3437,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2534,11 +3458,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2551,11 +3481,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2568,11 +3504,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2583,11 +3525,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2616,11 +3564,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2653,11 +3607,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2666,11 +3626,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2681,11 +3647,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2698,11 +3670,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2715,11 +3693,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2730,11 +3714,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2763,11 +3753,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2796,11 +3792,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2809,11 +3811,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2824,11 +3832,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2841,11 +3855,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2858,11 +3878,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2873,11 +3899,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2906,11 +3938,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2941,11 +3979,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2954,11 +3998,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2969,11 +4019,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -2986,11 +4042,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3003,11 +4065,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3018,11 +4086,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3051,11 +4125,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3086,11 +4166,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3099,11 +4185,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3112,11 +4204,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3125,11 +4223,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3138,11 +4242,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3151,10 +4261,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3163,11 +4275,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3176,11 +4294,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3189,11 +4313,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3202,11 +4332,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3215,11 +4351,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3228,11 +4370,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3241,11 +4389,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3254,10 +4408,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3266,11 +4422,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3279,10 +4441,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3291,10 +4455,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3303,11 +4469,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3316,10 +4488,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3328,11 +4502,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3341,11 +4521,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3354,10 +4540,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3366,11 +4554,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3379,11 +4573,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3392,11 +4592,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3405,11 +4611,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3418,10 +4630,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3430,11 +4644,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3443,11 +4663,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3456,11 +4682,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3469,11 +4701,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3482,11 +4720,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3495,11 +4739,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3508,11 +4758,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3521,11 +4777,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3534,11 +4796,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3547,10 +4815,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3559,11 +4829,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3572,10 +4848,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3584,10 +4862,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3596,11 +4876,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3609,10 +4895,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3621,11 +4909,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3634,11 +4928,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3647,10 +4947,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3659,11 +4961,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3672,10 +4980,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3684,10 +4994,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3696,10 +5008,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3708,10 +5022,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3720,10 +5036,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3732,10 +5050,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3744,10 +5064,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3756,11 +5078,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3769,10 +5097,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3781,10 +5111,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3793,11 +5125,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3806,10 +5144,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3818,11 +5158,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3831,10 +5177,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3843,10 +5191,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3855,11 +5205,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3868,10 +5224,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3880,11 +5238,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3893,11 +5257,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3906,10 +5276,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3918,11 +5290,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3931,10 +5309,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3943,11 +5323,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3956,11 +5342,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3969,11 +5361,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3982,11 +5380,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -3995,10 +5399,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4007,11 +5413,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4020,11 +5432,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4033,11 +5451,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4046,11 +5470,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4059,11 +5489,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4072,11 +5508,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4085,11 +5527,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4098,10 +5546,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4110,11 +5560,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4123,10 +5579,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4135,10 +5593,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4147,11 +5607,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4160,10 +5626,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4172,11 +5640,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4185,11 +5659,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4198,10 +5678,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4210,11 +5692,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4223,11 +5711,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4236,11 +5730,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4249,11 +5749,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4262,10 +5768,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4274,11 +5782,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4287,11 +5801,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4300,11 +5820,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4313,11 +5839,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4326,11 +5858,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4339,11 +5877,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4352,11 +5896,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4365,11 +5915,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4380,11 +5936,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4393,11 +5955,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4408,11 +5976,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4421,10 +5995,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4435,11 +6011,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4448,11 +6030,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4463,11 +6051,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4478,11 +6072,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4491,10 +6091,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4505,10 +6107,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4517,10 +6121,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4531,10 +6137,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4543,11 +6151,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4558,10 +6172,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4572,11 +6188,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4585,11 +6207,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4600,10 +6228,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4612,11 +6242,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4627,11 +6263,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4640,11 +6282,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4655,11 +6303,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4670,11 +6324,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4683,11 +6343,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4698,11 +6364,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4713,10 +6385,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4725,11 +6399,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4740,11 +6420,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4753,11 +6439,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4768,11 +6460,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4783,10 +6481,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4797,10 +6497,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4809,10 +6511,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4823,10 +6527,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4835,11 +6541,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4850,10 +6562,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4862,11 +6576,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4877,11 +6597,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4892,10 +6618,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4904,11 +6632,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4919,11 +6653,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4932,11 +6672,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4947,11 +6693,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4962,11 +6714,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4975,11 +6733,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -4990,11 +6754,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5003,10 +6773,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5017,11 +6789,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5032,11 +6810,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5045,11 +6829,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5060,11 +6850,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5073,10 +6869,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5087,10 +6885,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5099,10 +6899,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5113,10 +6915,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5127,11 +6931,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5140,10 +6950,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5154,11 +6966,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5169,11 +6987,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5182,10 +7006,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5196,11 +7022,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5211,11 +7043,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5224,11 +7062,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5239,11 +7083,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5254,11 +7104,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5267,11 +7123,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5280,11 +7142,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5293,11 +7161,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5306,11 +7180,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5321,11 +7201,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5334,11 +7220,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5349,11 +7241,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5362,11 +7260,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5375,11 +7279,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5388,11 +7298,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5403,11 +7319,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5420,11 +7342,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5437,11 +7365,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5452,11 +7386,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5465,11 +7405,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5480,11 +7426,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5497,11 +7449,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5514,11 +7472,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5529,11 +7493,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5542,11 +7512,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5555,11 +7531,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5570,11 +7552,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5587,11 +7575,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5604,11 +7598,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5619,11 +7619,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5652,11 +7658,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5687,11 +7699,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5700,11 +7718,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5715,11 +7739,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5732,11 +7762,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5749,11 +7785,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5764,11 +7806,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5797,11 +7845,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5834,11 +7888,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5847,11 +7907,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5862,11 +7928,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5879,11 +7951,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5896,11 +7974,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5911,11 +7995,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5944,11 +8034,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5977,11 +8073,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -5990,11 +8092,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6005,11 +8113,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6022,11 +8136,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6039,11 +8159,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6054,11 +8180,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6087,11 +8219,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6122,11 +8260,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6135,11 +8279,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6150,11 +8300,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6167,11 +8323,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6184,11 +8346,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6199,11 +8367,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6232,11 +8406,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": false,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6267,11 +8447,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6280,11 +8466,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6293,11 +8485,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6306,11 +8504,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6319,11 +8523,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6332,10 +8542,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6344,11 +8556,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6357,11 +8575,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6370,10 +8594,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6382,11 +8608,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6395,11 +8627,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6408,11 +8646,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6421,11 +8665,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6434,10 +8684,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6446,11 +8698,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6459,10 +8717,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6473,11 +8733,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6486,10 +8752,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6500,11 +8768,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6513,10 +8787,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6525,11 +8801,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6538,11 +8820,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6551,10 +8839,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6563,11 +8853,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6578,10 +8874,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6590,11 +8888,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6603,10 +8907,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6617,11 +8923,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6630,10 +8942,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6642,11 +8956,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6655,11 +8975,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6668,11 +8994,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6681,10 +9013,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6693,11 +9027,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6706,10 +9046,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6718,10 +9060,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6730,11 +9074,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6743,10 +9093,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6755,10 +9107,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6767,11 +9121,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6780,10 +9140,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6792,11 +9154,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6805,10 +9173,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6819,10 +9189,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6835,10 +9207,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6851,10 +9225,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6865,11 +9241,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6878,10 +9260,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6892,10 +9276,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6908,10 +9294,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6924,10 +9312,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6938,10 +9328,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6950,11 +9342,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6963,11 +9361,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6976,10 +9380,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -6988,11 +9394,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7001,10 +9413,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7013,10 +9427,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7025,11 +9441,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7038,10 +9460,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7050,10 +9474,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7062,11 +9488,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7075,10 +9507,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7087,11 +9521,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7102,10 +9542,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7118,10 +9560,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7132,10 +9576,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7148,10 +9594,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7160,11 +9608,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7173,10 +9627,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7189,10 +9645,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7203,10 +9661,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7219,10 +9679,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7233,10 +9695,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7247,11 +9711,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7260,11 +9730,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7275,11 +9751,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7288,10 +9770,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7302,11 +9786,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7315,10 +9805,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7329,11 +9821,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7344,11 +9842,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7357,10 +9861,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7371,10 +9877,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7387,10 +9895,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7403,10 +9913,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7417,11 +9929,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7430,10 +9948,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7446,10 +9966,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7460,10 +9982,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7476,10 +10000,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7490,11 +10016,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7503,11 +10035,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7518,11 +10056,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7533,10 +10077,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7545,11 +10091,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7560,10 +10112,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7572,11 +10126,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7587,11 +10147,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7602,10 +10168,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7616,10 +10184,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7632,10 +10202,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7648,10 +10220,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7660,11 +10234,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7675,10 +10255,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7691,10 +10273,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7705,10 +10289,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7721,10 +10307,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7735,11 +10323,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7748,11 +10342,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7763,11 +10363,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7776,10 +10382,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7790,11 +10398,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7805,10 +10419,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7817,11 +10433,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7832,11 +10454,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7845,10 +10473,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7859,10 +10489,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7875,10 +10507,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7891,10 +10525,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7905,11 +10541,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7920,10 +10562,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7936,10 +10580,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7950,10 +10596,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7966,10 +10614,12 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7980,11 +10630,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -7993,11 +10649,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8006,11 +10668,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8019,11 +10687,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8032,11 +10706,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8047,11 +10727,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8060,11 +10746,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8075,11 +10767,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8088,11 +10786,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8101,11 +10805,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8114,11 +10824,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8129,11 +10845,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8146,11 +10868,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8163,11 +10891,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8178,11 +10912,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8191,11 +10931,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8206,11 +10952,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8223,11 +10975,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8240,11 +10998,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8255,11 +11019,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8268,11 +11038,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8281,11 +11057,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8296,11 +11078,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8313,11 +11101,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8330,11 +11124,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8345,11 +11145,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8378,11 +11184,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8413,11 +11225,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8426,11 +11244,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8441,11 +11265,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8458,11 +11288,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8475,11 +11311,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8490,11 +11332,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8523,11 +11371,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8560,11 +11414,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8573,11 +11433,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8588,11 +11454,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8605,11 +11477,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8622,11 +11500,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8637,11 +11521,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8670,11 +11560,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8703,11 +11599,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8716,11 +11618,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8731,11 +11639,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8748,11 +11662,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8765,11 +11685,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8780,11 +11706,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8813,11 +11745,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8848,11 +11786,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8861,11 +11805,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8876,11 +11826,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8893,11 +11849,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8910,11 +11872,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8925,11 +11893,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8958,11 +11932,17 @@ Object {
   "alwaysNotify": false,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -8993,11 +11973,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9006,11 +11992,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9019,11 +12011,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9032,11 +12030,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9045,11 +12049,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9058,10 +12068,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9070,11 +12082,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9083,11 +12101,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9096,10 +12120,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9108,11 +12134,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9121,11 +12153,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9134,11 +12172,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9147,11 +12191,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9160,10 +12210,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9172,11 +12224,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9185,10 +12243,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9197,10 +12257,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9209,11 +12271,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9222,10 +12290,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9234,10 +12304,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9246,11 +12318,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9259,10 +12337,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9271,11 +12351,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9284,11 +12370,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9297,10 +12389,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9309,11 +12403,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9322,10 +12422,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9334,10 +12436,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9346,11 +12450,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9359,10 +12469,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9371,10 +12483,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9383,11 +12497,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9396,10 +12516,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9408,11 +12530,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9421,11 +12549,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9434,11 +12568,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9447,10 +12587,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9459,11 +12601,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9472,10 +12620,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9484,10 +12634,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9496,11 +12648,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9509,10 +12667,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9521,10 +12681,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9533,11 +12695,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9546,10 +12714,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9558,11 +12728,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9571,10 +12747,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9583,10 +12761,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9595,10 +12775,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9607,10 +12789,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9619,10 +12803,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9631,10 +12817,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9643,10 +12831,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9655,10 +12845,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9667,10 +12859,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9679,10 +12873,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9691,11 +12887,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9704,10 +12906,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9716,10 +12920,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9728,10 +12934,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9740,10 +12948,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9752,10 +12962,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9764,10 +12976,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9776,10 +12990,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9788,10 +13004,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9800,10 +13018,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9812,10 +13032,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9824,10 +13046,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9836,11 +13060,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9849,11 +13079,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9862,10 +13098,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9874,11 +13112,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9887,10 +13131,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9899,10 +13145,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9911,11 +13159,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9924,10 +13178,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9936,10 +13192,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9948,11 +13206,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9961,10 +13225,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9973,11 +13239,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9986,10 +13258,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -9998,10 +13272,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10010,10 +13286,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10022,10 +13300,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10034,10 +13314,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10046,10 +13328,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10058,10 +13342,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10070,10 +13356,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10082,10 +13370,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10094,10 +13384,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10106,11 +13398,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10119,10 +13417,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10131,10 +13431,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10143,10 +13445,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10155,10 +13459,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10167,10 +13473,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10179,10 +13487,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10191,10 +13501,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10203,10 +13515,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10215,10 +13529,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10227,10 +13543,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10239,10 +13557,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10253,11 +13573,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10266,11 +13592,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10281,11 +13613,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10294,10 +13632,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10308,11 +13648,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10321,10 +13667,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10335,11 +13683,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10350,11 +13704,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10363,10 +13723,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10377,10 +13739,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10389,10 +13753,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10403,10 +13769,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10415,10 +13783,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10429,10 +13799,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10443,11 +13815,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10456,10 +13834,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10470,10 +13850,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10482,10 +13864,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10496,10 +13880,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10508,10 +13894,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10522,10 +13910,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10536,11 +13926,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10549,11 +13945,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10564,11 +13966,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10579,10 +13987,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10591,11 +14001,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10606,10 +14022,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10618,11 +14036,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10633,11 +14057,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10648,10 +14078,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10662,10 +14094,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10674,10 +14108,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10688,10 +14124,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10700,10 +14138,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10714,10 +14154,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10726,11 +14168,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10741,10 +14189,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10755,10 +14205,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10767,10 +14219,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10781,10 +14235,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10793,10 +14249,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10807,10 +14265,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10821,11 +14281,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10834,11 +14300,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10849,11 +14321,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10862,10 +14340,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10876,11 +14356,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10891,10 +14377,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10903,11 +14391,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10918,11 +14412,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10931,10 +14431,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10945,10 +14447,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10957,10 +14461,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10971,10 +14477,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10985,10 +14493,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -10997,10 +14507,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11011,11 +14523,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11026,10 +14544,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11038,10 +14558,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11052,10 +14574,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11066,10 +14590,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11078,10 +14604,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11092,10 +14620,12 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "onlyOnError": false,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11106,11 +14636,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11119,11 +14655,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11132,11 +14674,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11145,11 +14693,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11158,11 +14712,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11173,11 +14733,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11186,11 +14752,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11201,11 +14773,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11214,11 +14792,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11227,11 +14811,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11240,11 +14830,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11255,11 +14851,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11272,11 +14874,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11289,11 +14897,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11304,11 +14918,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11317,11 +14937,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11332,11 +14958,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11349,11 +14981,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11366,11 +15004,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11381,11 +15025,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11394,11 +15044,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11407,11 +15063,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11422,11 +15084,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11439,11 +15107,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11456,11 +15130,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11471,11 +15151,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11504,11 +15190,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11539,11 +15231,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11552,11 +15250,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11567,11 +15271,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11584,11 +15294,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11601,11 +15317,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11616,11 +15338,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11649,11 +15377,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": false,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11686,11 +15420,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11699,11 +15439,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11714,11 +15460,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11731,11 +15483,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11748,11 +15506,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11763,11 +15527,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11796,11 +15566,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11829,11 +15605,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11842,11 +15624,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11857,11 +15645,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11874,11 +15668,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11891,11 +15691,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11906,11 +15712,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11939,11 +15751,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11974,11 +15792,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -11987,11 +15811,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -12002,11 +15832,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -12019,11 +15855,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -12036,11 +15878,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -12051,11 +15899,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -12084,11 +15938,17 @@ Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 

--- a/test/__snapshots__/WebpackNotifierPlugin.test.ts.snap
+++ b/test/__snapshots__/WebpackNotifierPlugin.test.ts.snap
@@ -3,66 +3,106 @@
 exports[`WebpackNotifierPlugin child compilation errors ["successful"] undefined {"plugins":[{"level":"Error","levelCollectionKey":"errors"}]}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": undefined,
+    "line": undefined,
+  },
   "message": "Warning: Child Compilation Error",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin child compilation errors ["successful"] undefined {"plugins":[{"level":"Warning","levelCollectionKey":"warnings"}]}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": undefined,
+    "line": undefined,
+  },
   "message": "Warning: Child Compilation Warning",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin child compilation errors ["successful"] undefined {"plugins":[{"level":false},{"level":"Warning","levelCollectionKey":"warnings"}]}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": undefined,
+    "line": undefined,
+  },
   "message": "Warning: Child Compilation Warning",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin contentImage ["error"] {contentImage: {success: "../successImage.png"}, error: "../errorImage.png"}, warning: "../warningImage.png"}}: after "error" build 1`] = `
 Object {
   "contentImage": "__dirname/errorsImage.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin contentImage ["successful"] {contentImage: "../another-logo.png"}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/another-logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin contentImage ["successful"] {contentImage: {success: "../successImage.png"}, error: "../errorImage.png"}, warning: "../warningImage.png"}}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/successImage.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin contentImage ["warning"] {contentImage: {success: "../successImage.png"}, error: "../errorImage.png"}, warning: "../warningImage.png"}}: after "warning" build 1`] = `
 Object {
   "contentImage": "__dirname/warningsImage.png",
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin custom warning ["successful"] undefined: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": undefined,
+    "line": undefined,
+  },
   "message": "Warning: Custom Warning message",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -70,9 +110,15 @@ exports[`WebpackNotifierPlugin emoji message ["error"] {"emoji":true} %j: after 
 Object {
   "contentImage": "__dirname/logo.png",
   "emoji": true,
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "❌ Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -80,8 +126,10 @@ exports[`WebpackNotifierPlugin emoji message ["successful"] {"emoji":true} %j: a
 Object {
   "contentImage": "__dirname/logo.png",
   "emoji": true,
+  "location": undefined,
   "message": "✅ Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -89,8 +137,14 @@ exports[`WebpackNotifierPlugin emoji message ["successful"] {"emoji":true} {"plu
 Object {
   "contentImage": "__dirname/logo.png",
   "emoji": true,
+  "location": Object {
+    "column": undefined,
+    "file": undefined,
+    "line": undefined,
+  },
   "message": "⚠️ Warning: Custom Warning message",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -98,105 +152,157 @@ exports[`WebpackNotifierPlugin emoji message ["warning"] {"emoji":true} %j: afte
 Object {
   "contentImage": "__dirname/logo.png",
   "emoji": true,
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "⚠️ Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin one compilation ["error"] undefined: after "error" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin one compilation ["successful"] undefined: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin one compilation ["warning"] undefined: after "warning" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title ["error"] {}: after "error" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "build error ❌",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title ["successful"] {"title":"Webpack"}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title ["successful"] {}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "build complete ✅",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title ["warning"] {}: after "warning" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "title": "build warning ⚠️",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title new title function API ["error"] {}: after "error" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "Build status is error with message Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title new title function API ["successful"] {"title":"Webpack"}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title new title function API ["successful"] {}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Build status is success with message Build successful",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin title new title function API ["warning"] {}: after "warning" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": undefined,
+    "file": "/entry.js",
+    "line": undefined,
+  },
   "message": "Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
   "title": "Build status is warning with message Warning: /entry.js
 require.extensions is not supported by webpack. Use a loader instead.",
+  "wait": false,
 }
 `;
 
@@ -204,8 +310,10 @@ exports[`WebpackNotifierPlugin verbosity level configuration Always Notify ["suc
 Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -213,42 +321,60 @@ exports[`WebpackNotifierPlugin verbosity level configuration Always Notify ["suc
 Object {
   "alwaysNotify": true,
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin verbosity level configuration Default ["error","error","successful"] undefined: after "error" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin verbosity level configuration Default ["error","error","successful"] undefined: after "error" build 2`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin verbosity level configuration Default ["error","error","successful"] undefined: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin verbosity level configuration Default ["successful","successful","successful"] undefined: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -260,18 +386,26 @@ exports[`WebpackNotifierPlugin verbosity level configuration Exclude Warnings ["
 Object {
   "contentImage": "__dirname/logo.png",
   "excludeWarnings": true,
+  "location": undefined,
   "message": "Build successful",
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
 exports[`WebpackNotifierPlugin verbosity level configuration Notify on error ["successful","warning","error"] {"onlyOnError":true}: after "error" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": Object {
+    "column": 8,
+    "file": "/entry.js",
+    "line": 1,
+  },
   "message": "Error: /entry.js
 SyntaxError: Unexpected token (1:8)",
   "onlyOnError": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;
 
@@ -284,8 +418,10 @@ exports[`WebpackNotifierPlugin verbosity level configuration Skip Notification o
 exports[`WebpackNotifierPlugin verbosity level configuration Skip Notification on the First Build ["successful","successful"] {"skipFirstNotification":true}: after "successful" build 2`] = `
 Object {
   "contentImage": "__dirname/logo.png",
+  "location": undefined,
   "message": "Build successful",
   "skipFirstNotification": true,
   "title": "Webpack",
+  "wait": false,
 }
 `;

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -65,7 +65,7 @@ export const reduceArraySerializer = {
     return Array.isArray(val) &&
       val.length === 1 &&
       Array.isArray(val[0]) &&
-      val[0].length === 1 &&
+      val[0].length === 2 &&
       typeof val[0][0] === 'object' &&
       val[0][0].hasOwnProperty('title');
   },
@@ -86,6 +86,16 @@ export const contentImageSerializer = {
     }
     delete modifiedVal.icon;
     return printer(modifiedVal, config, indentation, depth, refs);
+  },
+};
+export const skipNotifierCallback = {
+  test(val) {
+    return Array.isArray(val) &&
+      val.length === 2 &&
+      true;
+  },
+  serialize(val, config, indentation, depth, refs, printer) {
+    return printer(val.slice(0, 1), config, indentation, depth, refs);
   },
 };
 export const changedOptionsSerializer = {

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -90,11 +90,9 @@ export const contentImageSerializer = {
 };
 export const changedOptionsSerializer = {
   test(val) {
-    return typeof val === 'object' && val.hasOwnProperty('location');
+    return false;
   },
   serialize(val, config, indentation, depth, refs, printer) {
-    delete val.location;
-    delete val.wait;
     return printer(val, config, indentation, depth, refs);
   },
 };

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -88,6 +88,16 @@ export const contentImageSerializer = {
     return printer(modifiedVal, config, indentation, depth, refs);
   },
 };
+export const changedOptionsSerializer = {
+  test(val) {
+    return typeof val === 'object' && val.hasOwnProperty('location');
+  },
+  serialize(val, config, indentation, depth, refs, printer) {
+    delete val.location;
+    delete val.wait;
+    return printer(val, config, indentation, depth, refs);
+  },
+};
 
 export type Sources = string[];
 export type PluginOptions = {} | undefined;


### PR DESCRIPTION
- [ ] check click event on different platforms
  * [ ] Linux / NotifySend
  * [ ] Linux / NotificationCenter
  * [ ] Windows <8 / WindowsBalloon
  * [ ] Windows >=8 / WindowsBalloon
  * [ ] Windows >=8 / WindowsToaster
  * [ ] WSL / WindowsToaster
  * [ ] BSD / NotifySend (non-critical)
  * [ ] MacOS / Growl (non-critical)
  * [ ] Windows / Growl (non-critical)
- [ ] more examples in documentation for different popular editors/IDE
- [ ] cover by tests
- [ ] wait for release of bugfix [node-notifier#347](https://github.com/mikaelbr/node-notifier/pull/347)
  