### PR TITLE
[wip] passing `node-notifier` options

### DIFF
--- a/test/WebpackNotifierPlugin.test.ts
+++ b/test/WebpackNotifierPlugin.test.ts
@@ -104,4 +104,9 @@ describe('WebpackNotifierPlugin', () => {
       [['successful'], undefined, {plugins: [new ChildCompilationPlugin(), new ChildCompilationPlugin('Warning')]}],
     ])('%j %j %j', testChangesFlow, 10e3);
   });
+  describe('child compilation errors', () => {
+    test.each([
+      [['successful'], {appId: 'com.squirrel.your.app'}],// TODO mark as deprecate at v2.x
+    ])('%j %j %j', testChangesFlow, 10e3);
+  });
 });

--- a/test/__snapshots__/WebpackNotifierPlugin.test.ts.snap
+++ b/test/__snapshots__/WebpackNotifierPlugin.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`WebpackNotifierPlugin child compilation errors ["successful"] {"appId":"com.squirrel.your.app"} %j: after "successful" build 1`] = `
+Object {
+  "appId": "com.squirrel.your.app",
+  "contentImage": "__dirname/logo.png",
+  "message": "Build successful",
+  "title": "Webpack",
+}
+`;
+
 exports[`WebpackNotifierPlugin child compilation errors ["successful"] undefined {"plugins":[{"level":"Error","levelCollectionKey":"errors"}]}: after "successful" build 1`] = `
 Object {
   "contentImage": "__dirname/logo.png",


### PR DESCRIPTION
- [ ]  testing direct passing otpions
- [ ] document it
- [ ] support custom sub-options like
```js
new WebpackNotifierPlugin ({
  notifier: 'NotificationCenter',// or constructor - require('node-notifier').NotificationCenter
  notifierOptions: {
    withFallback: false,
    customPath: undefined
  },
  notifyOptions: {
    appID: 'com.squirrel.your.app'
  }
});
```
